### PR TITLE
Fixes broken HTML integration link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ This proposal would be a small expansion of the existing JavaScript and HTML cap
 
 The ideas in the Loader specification would largely stay the same, although probably this would either supplant the current `System.loader.import()` proposal or make `System.loader.import()` a lower-level version that is used in specialized circumstances. The Loader specification would continue to work on prototyping more general ideas for pluggable loading pipelines and reflective modules, which over time could be used to generalize HTML and Node's host-specific pipelines.
 
-Concretely, this repository is intended as a TC39 proposal to advance through the stages process, specifying the `import()` syntax and the relevant host environment hooks. It also contains [an outline of proposed changes to the HTML Standard](HTML Integration.md) that would integrate with this proposal.
+Concretely, this repository is intended as a TC39 proposal to advance through the stages process, specifying the `import()` syntax and the relevant host environment hooks. It also contains [an outline of proposed changes to the HTML Standard](HTML%20Integration.md) that would integrate with this proposal.


### PR DESCRIPTION
I noticed the whitespace character in the filename `HTML Integration.md` was breaking GitHub's Markdown link formatting, resulted in an unformatted hyperlink. I've fixed that in this admittedly trivial PR by adding `%20` to the filename. 

*The repo doesn't have a `CONTRIBUTING.md` file and I'm not sure the process for contributing to tc39 proposals such as this, so please feel free to simply close this PR if it's something you'd like to fix yourselves later on, and apologies for the hassle if that is in fact the case.*