### PR TITLE
Remove assert that doesn't always hold

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -242,7 +242,6 @@ contributors: Domenic Denicola
       <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
       <emu-alg>
         1. Let _referencingScriptOrModule_ be ! GetActiveScriptOrModule().
-        1. Assert: _referencingScriptOrModule_ is a Script Record or Module Record (i.e. is not *null*).
         1. Let _argRef_ be the result of evaluating |AssignmentExpression|.
         1. Let _specifier_ be ? GetValue(_argRef_).
         1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).


### PR DESCRIPTION
As per https://github.com/whatwg/html/issues/3295 it seems that _referencingScriptOrModule_ can be NULL in the context of `import()` in an event handler, which is good motivation to drop this Assert since it effectively "crashes" the spec as currently written.