### PR TITLE
FinishDynamicImport: update _specifierString_ to _specifier_

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -109,7 +109,7 @@ contributors: Domenic Denicola
         1. If _completion_ is an abrupt completion, then perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _completion_.[[Value]] »).
         1. Otherwise,
           1. Assert: _completion_ is a normal completion and _completion_.[[Value]] is *undefined*.
-          1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifierString_).
+          1. Let _moduleRecord_ be ! HostResolveImportedModule(_referencingScriptOrModule_, _specifier_).
           1. Assert: Evaluate has already been invoked on _moduleRecord_ and successfully completed.
           1. Let _namespace_ be GetModuleNamespace(_moduleRecord_).
           1. If _namespace_ is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, « _namespace_.[[Value]] »).


### PR DESCRIPTION
This abstract operation receives an argument named _specifier_, not _specifierString_